### PR TITLE
Feature/brian os network workaround

### DIFF
--- a/lib/cluster/setup.pm
+++ b/lib/cluster/setup.pm
@@ -117,8 +117,8 @@ sub setup_vagrantfile {
         # HACK: this is a hack because we don't properly templatize the Vagrantfile... I'm doing this to eliminate empty os.network and os.floating_ip which cause problems on various OpenStack clouds
         $full_output =~ s/os.network = "<FILLMEIN>"//;
         $full_output =~ s/os.network = ""//;
-	$full_output =~ s/os.networks = \[ "<FILLMEIN>" \]//;
-	$full_output =~ s/os.networks = \[ "" \]//;
+	$full_output =~ s/os.networks = \[ "<FILLMEIN>" \]/os.networks = \[ \]/;
+	$full_output =~ s/os.networks = \[ "" \]/os.networks = \[ \]/;
         $full_output =~ s/os.floating_ip = "<FILLMEIN>"//;
         $full_output =~ s/os.floating_ip = ""//;
         open my $vout, '>', $node_output;


### PR DESCRIPTION
Hi @amishpatel1994, can you take a look at this pull request and try it out on the old and new OpenStack clusters at OICR?  This just adds code to properly deal with user specify an empty string in the network config. In OpenStack at BioNimbus it needs to have the following be in the Vagrantfile:

os.networks = [ ]

Right now an empty string (e.g. no network name) in our config means you get:

os.networks = [ "" ]

In the vagrantfile which is not handled properly by the openstack plugin.

I'm testing on:

Vagrant 1.6.3
vagrant-openstack-plugin (0.7.0)
